### PR TITLE
fix: revert commit reference to 6fa56d4

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@
 # HTTP server for boot files (no k8s access, talks to controller via gRPC)
 http:
   port: 8080
-  commit: "1d33ee6"  # Git commit to install
+  commit: "6fa56d4"  # Git commit to install
   resources:
     limits:
       memory: "2Gi"
@@ -16,7 +16,7 @@ http:
 
 # Controller (manages deploys, talks to k8s API)
 controller:
-  commit: "1d33ee6"  # Git commit to install
+  commit: "6fa56d4"  # Git commit to install
   resources:
     limits:
       memory: "2Gi"


### PR DESCRIPTION
## Summary
- Revert commit references from `1d33ee6` back to `6fa56d4`
- The commit `1d33ee6` was reverted from isoboot main

## Context
This fixes the chart to reference a valid commit. Once isoboot#2 is merged, we can update to the new commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)