### PR TITLE
chore: update to isoboot commit 595705b

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@
 # HTTP server for boot files (no k8s access, talks to controller via gRPC)
 http:
   port: 8080
-  commit: "6fa56d4"  # Git commit to install
+  commit: "595705b"  # Git commit to install
   resources:
     limits:
       memory: "2Gi"
@@ -16,7 +16,7 @@ http:
 
 # Controller (manages deploys, talks to k8s API)
 controller:
-  commit: "6fa56d4"  # Git commit to install
+  commit: "595705b"  # Git commit to install
   resources:
     limits:
       memory: "2Gi"


### PR DESCRIPTION
## Summary
- Update http and controller commits to `595705b`
- Includes lazy gRPC connection fix from isoboot#2

## Test plan
- [ ] Deploy and verify pods start correctly regardless of startup order

🤖 Generated with [Claude Code](https://claude.com/claude-code)