### PR TITLE
fix: add dnsPolicy for hostNetwork pod to resolve cluster DNS

### DIFF
--- a/templates/pod-http.yaml
+++ b/templates/pod-http.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   restartPolicy: Always
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: http
       image: "golang:1.25-alpine"


### PR DESCRIPTION
## Summary
- Add `dnsPolicy: ClusterFirstWithHostNet` to HTTP pod
- Pods with `hostNetwork: true` use host DNS by default
- This allows the HTTP pod to resolve `*.svc.cluster.local` names to reach the controller

## Root cause
The HTTP pod couldn't reach the controller gRPC service because it couldn't resolve the DNS name. Host DNS doesn't know about cluster services.

## Test plan
- [ ] Deploy and verify `/boot/boot.ipxe` returns 200 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)