### PR TITLE
feat: use Hostname instead of MAC in preseed URL

### DIFF
--- a/files/debian-13.ipxe
+++ b/files/debian-13.ipxe
@@ -1,5 +1,5 @@
 #!ipxe
 kernel http://{{ .Host }}:{{ .Port }}/iso/content/debian-13/mini.iso/linux
 initrd http://{{ .Host }}:{{ .Port }}/iso/content/debian-13/mini.iso/initrd.gz
-imgargs linux initrd=initrd.gz auto=true priority=critical ipv6.disable=1 netcfg/choose_interface=auto mirror/http/proxy=http://{{ .Host }}:3128 preseed/url=http://{{ .Host }}:{{ .Port }}/dynamic/{{ .MAC }}/debian-13/preseed.cfg --- quiet
+imgargs linux initrd=initrd.gz auto=true priority=critical ipv6.disable=1 netcfg/choose_interface=auto mirror/http/proxy=http://{{ .Host }}:3128 preseed/url=http://{{ .Host }}:{{ .Port }}/dynamic/{{ .Hostname }}/debian-13/preseed.cfg --- quiet
 boot


### PR DESCRIPTION
## Summary
- Change preseed URL to use `{{ .Hostname }}` instead of `{{ .MAC }}`
- Depends on isoboot#4 for Hostname support in template data

## Test plan
- [ ] Merge isoboot#4 first
- [ ] Update commit hash to include Hostname support
- [ ] Deploy and verify preseed URL uses hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)