### PR TITLE
feat: reduce squid shutdown wait time to 5 seconds

### DIFF
--- a/templates/deployment-squid.yaml
+++ b/templates/deployment-squid.yaml
@@ -77,6 +77,9 @@ spec:
               # Cache aggressively for boot files
               refresh_pattern -i \.(iso|gz|cpio|kpxe|efi)$ 10080 90% 43200 override-expire ignore-no-cache ignore-no-store
               refresh_pattern . 0 20% 4320
+
+              # Fast shutdown (default 30s)
+              shutdown_lifetime 5 seconds
               SQUID_EOF
 
               echo "Initializing cache..."


### PR DESCRIPTION
## Summary
- Reduce squid `shutdown_lifetime` from default 30s to 5s for faster pod termination

## Test plan
- [ ] Redeploy and verify squid terminates quickly

🤖 Generated with [Claude Code](https://claude.com/claude-code)