### PR TITLE
chore: update to isoboot 065f25e

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@
 # HTTP server for boot files (no k8s access, talks to controller via gRPC)
 http:
   port: 8080
-  commit: "a43c69d"  # Git commit to install
+  commit: "065f25e"  # Git commit to install
   resources:
     limits:
       memory: "2Gi"
@@ -16,7 +16,7 @@ http:
 
 # Controller (manages deploys, talks to k8s API)
 controller:
-  commit: "a43c69d"  # Git commit to install
+  commit: "065f25e"  # Git commit to install
   resources:
     limits:
       memory: "2Gi"


### PR DESCRIPTION
## Summary
Update isoboot commit to include the ISO handler fix required for the new BootTarget naming.

## Includes
- isoboot#19: fix: look up BootTarget first to get diskImageRef for config lookup
- isoboot#20: test: add tests for HTTP middleware and controllerclient

## Why
Without #19, requests to `/iso/content/debian-13-with-firmware/...` return 404 because the handler tries to look up config using the BootTarget name instead of the DiskImage name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)