### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-01-26
+
+### Added
+- DiskImage CRD for managing ISO downloads with checksum verification
+- BootTarget CRD for defining boot configurations per disk image
+- ResponseTemplate CRD for dynamic response file generation
+- `includeFirmwarePath` field in BootTarget for firmware merging
+- Separate BootTargets for debian-13 (with and without firmware)
+- ISO storage volume mounted to controller for DiskImage downloads
+- Squid proxy cache for boot file downloads
+
+### Changed
+- Renamed `target` to `bootTargetRef` in Deploy CRD
+- Converted controller and HTTP from Pods to Deployments (auto-restart)
+- Reduced squid shutdown wait time to 5 seconds
+
+### Fixed
+- Checksum verification now uses exact relative path matching
+- Basename fallback for checksum files with only base filenames
+- SHA256SUMS with multiple same-named files (e.g., netboot/mini.iso vs netboot/gtk/mini.iso)
+
+### Tested With
+- Debian 13 (trixie) netboot with SHA256 verification
+- Firmware merging with firmware.cpio.gz
+
 ## [0.3.0] - 2026-01-24
 
 ### Added

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: isoboot-chart
 description: PXE boot proxy DHCP server with Debian netboot support
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.4.0
+appVersion: "0.4.0"

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -1,6 +1,6 @@
 # Milestones
 
-## v0.1.0 - PXE Boot Infrastructure (Complete)
+## v0.1.0 - PXE Boot Infrastructure ✅
 
 - Proxy DHCP with dnsmasq
 - iPXE chainloading (BIOS + UEFI)
@@ -8,7 +8,7 @@
 
 ---
 
-## v0.2.0 - Debian 13 Netboot (Complete)
+## v0.2.0 - Debian 13 Netboot ✅
 
 - HTTP server serving boot files (kernel, initrd)
 - On-demand ISO download with caching
@@ -19,7 +19,7 @@
 
 ---
 
-## v0.3.0 - Controller/HTTP Split (Complete)
+## v0.3.0 - Controller/HTTP Split ✅
 
 - Separate controller and HTTP pods for security
 - Controller has k8s API access, HTTP does not
@@ -29,9 +29,20 @@
 
 ---
 
-## v0.4.0 - Preseed Automation (Next)
+## v0.4.0 - CRD Framework & Checksum Verification ✅
 
-**Objective:** Fully automated Debian installation with preseed.
+- DiskImage CRD for ISO downloads with checksum verification
+- BootTarget CRD for boot configurations
+- ResponseTemplate CRD for dynamic response files
+- `includeFirmwarePath` for firmware merging
+- Exact relative path matching for checksums
+- Deployments instead of Pods (auto-restart)
+
+---
+
+## v0.5.0 - Preseed Automation (Next)
+
+**Objective:** Fully automated Debian 13 installation with preseed.
 
 ### Features
 - Preseed template with variables (hostname, domain, root password, etc.)
@@ -44,46 +55,109 @@
 ```yaml
 apiVersion: isoboot.io/v1alpha1
 kind: Deploy
-metadata:
-  name: vm03-debian-13
 spec:
   machineRef: vm03
-  bootTargetRef: debian-13
-  preseed:
+  bootTargetRef: debian-13-with-firmware
+  config:
     hostname: vm03
     domain: local
     timezone: America/Los_Angeles
     locale: en_US.UTF-8
-    rootPassword: "$6$..." # hashed
+    rootPasswordHash: "$6$..."
     partitioning: lvm-single-disk
     packages:
       - openssh-server
       - vim
-    lateCommand: |
-      curl -X POST http://{{.Host}}:{{.Port}}/api/deploy/{{.Hostname}}/complete
 ```
 
 ---
 
-## v0.5.0 - Multi-OS Support (Future)
+## v0.6.0 - Debian 12 (Bookworm)
 
-- Ubuntu Server support
-- Rocky Linux / AlmaLinux support
-- OS-specific templates (preseed, autoinstall, kickstart)
+**Objective:** Add Debian 12 stable support.
+
+### Features
+- Debian 12 DiskImage and BootTargets
+- Preseed template for Debian 12
+- Tested automated installation
+
+### Targets
+- debian-12-no-firmware
+- debian-12-with-firmware
 
 ---
 
-## v0.6.0 - Boot Menu (Future)
+## v0.7.0 - Ubuntu Server
 
-- Interactive boot menu for multiple OS options
+**Objective:** Ubuntu Server support with autoinstall.
+
+### Features
+- Ubuntu autoinstall (cloud-init) templates
+- ResponseTemplate for autoinstall YAML generation
+- Subiquity-based installation
+
+### Targets
+- ubuntu-22.04 (Jammy Jellyfish LTS)
+- ubuntu-24.04 (Noble Numbat LTS)
+- ubuntu-25.10 (latest)
+
+---
+
+## v0.8.0 - Rocky Linux
+
+**Objective:** Rocky Linux support with kickstart.
+
+### Features
+- Kickstart template generation
+- ResponseTemplate for kickstart files
+- Anaconda-based installation
+
+### Targets
+- rocky-9
+- rocky-10
+
+---
+
+## v0.9.0 - Alma Linux
+
+**Objective:** Alma Linux support with kickstart.
+
+### Features
+- Kickstart template (shared with Rocky)
+- ResponseTemplate for kickstart files
+
+### Targets
+- alma-9
+- alma-10
+
+---
+
+## v1.0.0 - Production Ready
+
+**Objective:** Stable release with full multi-distro support.
+
+### Supported Distributions
+| Distro | Versions | Installer |
+|--------|----------|-----------|
+| Debian | 12, 13 | Preseed |
+| Ubuntu | 22.04, 24.04, 25.10 | Autoinstall |
+| Rocky Linux | 9, 10 | Kickstart |
+| Alma Linux | 9, 10 | Kickstart |
+
+### Features
+- Boot menu for multiple OS options
 - Default timeout with auto-boot
 - Machine-specific menu customization
+- Comprehensive documentation
+- Production hardening
 
 ---
 
-## Future Ideas
+## Future Ideas (Post 1.0)
 
 - Web UI for managing machines and deploys
 - PXE boot logging and metrics
 - Integration with external IPAM
 - Cloud-init support for cloud images
+- Windows Server support (WinPE/MDT)
+- ESXi support


### PR DESCRIPTION
## Summary
Release v0.4.0 - CRD Framework & Checksum Verification

### Added
- DiskImage CRD for managing ISO downloads with checksum verification
- BootTarget CRD for defining boot configurations per disk image
- ResponseTemplate CRD for dynamic response file generation
- `includeFirmwarePath` field in BootTarget for firmware merging
- Separate BootTargets for debian-13 (with and without firmware)
- ISO storage volume mounted to controller for DiskImage downloads

### Changed
- Renamed `target` to `bootTargetRef` in Deploy CRD
- Converted controller and HTTP from Pods to Deployments (auto-restart)

### Fixed
- Checksum verification now uses exact relative path matching
- Basename fallback for checksum files with only base filenames
- SHA256SUMS with multiple same-named files

### Milestones Updated
Roadmap to v1.0.0 with support for:
- Debian 12, 13
- Ubuntu 22.04, 24.04, 25.10
- Rocky Linux 9, 10
- Alma Linux 9, 10

## After Merge
Create tag v0.4.0 and push it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)