### PR TITLE
feat: add Verifying phase to DiskImage CRD

### DIFF
--- a/crds/diskimage.yaml
+++ b/crds/diskimage.yaml
@@ -32,6 +32,7 @@ spec:
                   type: string
                   enum:
                     - Pending
+                    - Verifying
                     - Downloading
                     - Complete
                     - Failed


### PR DESCRIPTION
## Summary
Add "Verifying" to the DiskImage phase enum so controller can indicate when it's checking existing files rather than downloading.

## Changes
- Add "Verifying" to `.status.phase` enum in diskimage.yaml CRD

## Related
- Companion to isoboot/isoboot#23

## Test plan
- [ ] CRD applies without error
- [ ] DiskImage shows "Verifying" when files exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)