### PR TITLE
release: v0.5.0 - Preseed Automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-01-27
+
+### Added
+- IP tracking in Provision status - captures source IP when `/boot/done` is called
+- IP column in `kubectl get provision` output
+- Completion callback endpoint (`/boot/done?id={hostname}`)
+- Console-only Debian installation with SSH server
+
+### Changed
+- Renamed Deploy CRD to Provision (avoid confusion with Kubernetes Deployment)
+- Simplified pod names: `isoboot-controller` instead of `isoboot-isoboot-chart-controller`
+- Updated RBAC rules for `provisions` resource
+
+### Technical Details
+- Provision status now includes `ip` field populated on completion
+- Proto updated with `ip` field in `MarkBootCompletedRequest`
+- Uses `net.SplitHostPort()` for IPv6-compatible IP extraction
+
+### Tested With
+- Debian 13 (trixie) automated installation via preseed
+- QEMU VM with UEFI PXE boot on Raspberry Pi 5 cluster
+- IP tracking verified in kubectl output
+
 ## [0.4.0] - 2026-01-26
 
 ### Added

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -40,39 +40,29 @@
 
 ---
 
-## v0.5.0 - Preseed Automation (Next)
+## v0.5.0 - Preseed Automation ✅
 
-**Objective:** Fully automated Debian 13 installation with preseed.
-
-### Features
-- Preseed template with variables (hostname, domain, root password, etc.)
-- Per-machine preseed configuration via Provision CRD
-- Late command support for post-install customization
-- Completion callback to mark Provision as Complete
-- Partitioning presets (single disk, LVM, etc.)
-
-### Provision CRD Extension
-```yaml
-apiVersion: isoboot.io/v1alpha1
-kind: Provision
-spec:
-  machineRef: vm03
-  bootTargetRef: debian-13-with-firmware
-  config:
-    hostname: vm03
-    domain: local
-    timezone: America/Los_Angeles
-    locale: en_US.UTF-8
-    rootPasswordHash: "$6$..."
-    partitioning: lvm-single-disk
-    packages:
-      - openssh-server
-      - vim
-```
+- Renamed Deploy CRD to Provision (clearer naming)
+- Simplified pod names (isoboot-controller, isoboot-http)
+- Completion callback via `/boot/done` endpoint
+- IP tracking in Provision status
+- Console-only Debian installation with SSH
+- Preseed template with ResponseTemplate CRD
 
 ---
 
-## v0.6.0 - Debian 12 (Bookworm)
+## v0.6.0 - SSH & Security (Next)
+
+**Objective:** SSH key management and security hardening.
+
+### Features
+- SSH authorized_keys per user via ConfigMap/Secret
+- SSH host key injection (avoid known_hosts warnings)
+- SSH key-only authentication (disable password login)
+
+---
+
+## v0.7.0 - Debian 12 (Bookworm)
 
 **Objective:** Add Debian 12 stable support.
 
@@ -87,7 +77,7 @@ spec:
 
 ---
 
-## v0.7.0 - Ubuntu Server
+## v0.8.0 - Ubuntu Server
 
 **Objective:** Ubuntu Server support with autoinstall.
 
@@ -103,7 +93,7 @@ spec:
 
 ---
 
-## v0.8.0 - Rocky Linux
+## v0.9.0 - Rocky Linux
 
 **Objective:** Rocky Linux support with kickstart.
 
@@ -118,7 +108,7 @@ spec:
 
 ---
 
-## v0.9.0 - Alma Linux
+## v0.10.0 - Alma Linux
 
 **Objective:** Alma Linux support with kickstart.
 


### PR DESCRIPTION
## v0.5.0 Release

### Added
- IP tracking in Provision status - captures source IP when `/boot/done` is called
- IP column in `kubectl get provision` output
- Completion callback endpoint (`/boot/done?id={hostname}`)
- Console-only Debian installation with SSH server

### Changed
- Renamed Deploy CRD to Provision (avoid confusion with Kubernetes Deployment)
- Simplified pod names: `isoboot-controller` instead of `isoboot-isoboot-chart-controller`
- Updated RBAC rules for `provisions` resource

### Tested With
- Debian 13 (trixie) automated installation via preseed
- QEMU VM with UEFI PXE boot on Raspberry Pi 5 cluster
- IP tracking verified in kubectl output

🤖 Generated with [Claude Code](https://claude.com/claude-code)