### PR TITLE
Create 01-basic-debian-12.md

### DIFF
--- a/examples/01-basic-debian-12.md
+++ b/examples/01-basic-debian-12.md
@@ -6,7 +6,7 @@ kubectl apply -n isoboot -f - <<EOF
 apiVersion: isoboot.io/v1alpha1
 kind: Machine
 metadata:
-  name: vm-deb-13.lan
+  name: vm-deb-12.lan
 spec:
   mac: "52-54-00-26-10-13"
 EOF


### PR DESCRIPTION
This pull request adds a new example guide for provisioning a basic Debian 12 machine using isoboot. The guide walks through creating the necessary Kubernetes resources and configuration for an automated Debian installation.

Documentation additions:

* Added a new `examples/01-basic-debian-12.md` file that provides a step-by-step guide for:
  - Creating a `Machine` resource for Debian 12 provisioning
  - Defining a `ResponseTemplate` with a preseed configuration for Debian installation
  - Creating a `ConfigMap` to supply user and localization data, including instructions for generating a password hash
  - Linking all resources together using a `Provision` resource