### PR TITLE
Create 02-basic-debian-13-with-public-ssh-key.md.md

### DIFF
--- a/examples/02-basic-debian-13-with-public-ssh-key.md.md
+++ b/examples/02-basic-debian-13-with-public-ssh-key.md.md
@@ -40,7 +40,7 @@ spec:
         wget -qO- http://{{ .Host }}:{{ .Port }}/boot/done?id={{ .Hostname }} && \
         in-target mkdir -p /home/{{ .username }}/.ssh && \
         in-target chmod 700 /home/{{ .username }}/.ssh && \
-        in-target touch 700 /home/{{ .username }}/.ssh/authorized_keys && \
+        in-target touch /home/{{ .username }}/.ssh/authorized_keys && \
         echo '{{ .sshPublicKey }}' > /target/home/{{ .username }}/.ssh/authorized_keys && \
         in-target chmod 600 /home/{{ .username }}/.ssh/authorized_keys && \
         in-target chown -R {{ .username }}:{{ .username }} /home/{{ .username }}/.ssh


### PR DESCRIPTION
This pull request adds a new example guide for provisioning a basic Debian 13 machine with a public SSH key using Kubernetes custom resources. The guide provides step-by-step instructions for creating the necessary resources and connecting to the provisioned machine via SSH.

Documentation improvements:

* Added a new markdown file `examples/02-basic-debian-13-with-public-ssh-key.md.md` with a detailed walkthrough for provisioning a Debian 13 VM, including creating `Machine`, `ResponseTemplate`, `ConfigMap`, and `Provision` resources, as well as instructions for generating a password hash and connecting via SSH.