### PR TITLE
chore: update isoboot to 9fe94cb

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@
 # HTTP server for boot files (no k8s access, talks to controller via gRPC)
 http:
   port: 8080
-  commit: "f94b81d"  # Git commit to install
+  commit: "9fe94cb"  # Git commit to install
   resources:
     limits:
       memory: "2Gi"
@@ -16,7 +16,7 @@ http:
 
 # Controller (manages provisions, talks to k8s API)
 controller:
-  commit: "f94b81d"  # Git commit to install
+  commit: "9fe94cb"  # Git commit to install
   resources:
     limits:
       memory: "2Gi"


### PR DESCRIPTION
## Summary
- Updates controller and http to commit `9fe94cb`

## Changes in this update
- feat: derive SSH public keys from private keys in secrets (#30)

This enables automatic derivation of SSH public keys from private keys stored in secrets, allowing templates to inject host keys to avoid SSH known_hosts warnings after reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)