### PR TITLE
chore: update isoboot to 926793a

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@
 # HTTP server for boot files (no k8s access, talks to controller via gRPC)
 http:
   port: 8080
-  commit: "9fe94cb"  # Git commit to install
+  commit: "926793a"  # Git commit to install
   resources:
     limits:
       memory: "512Mi"
@@ -16,7 +16,7 @@ http:
 
 # Controller (manages provisions, talks to k8s API)
 controller:
-  commit: "9fe94cb"  # Git commit to install
+  commit: "926793a"  # Git commit to install
   resources:
     limits:
       memory: "512Mi"


### PR DESCRIPTION
## Summary
- Updates controller and http to commit `926793a`

## Changes in this update
- `b64enc` template function for base64 encoding (Helm-style)
- Ed25519 key type handling fix for SSH key derivation
- Path traversal protection with regex validation for diskImageRef
- IP preservation fix in UpdateProvisionStatus
- CLAUDE.md docs corrected for template variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)