### PR TITLE
feat: add optional machineId field to Machine CRD

### DIFF
--- a/crds/CLAUDE.md
+++ b/crds/CLAUDE.md
@@ -16,7 +16,7 @@ spec:
   machineId: "0123456789abcdef0123456789abcdef"  # optional, 32 hex chars
 ```
 - `mac` (required): MAC address, dash-separated
-- `machineId` (optional): systemd machine-id for /etc/machine-id (exactly 32 hex characters)
+- `machineId` (optional): systemd machine-id for /etc/machine-id (exactly 32 lowercase hex characters)
 
 ### DiskImage
 Downloads and caches ISO images with checksum verification.

--- a/crds/machine.yaml
+++ b/crds/machine.yaml
@@ -33,8 +33,8 @@ spec:
                   description: MAC address for this machine (dash-separated, e.g., aa-bb-cc-dd-ee-ff)
                 machineId:
                   type: string
-                  pattern: "^[0-9a-fA-F]{32}$"
-                  description: Optional systemd machine-id (32 hex characters, used for /etc/machine-id)
+                  pattern: "^[0-9a-f]{32}$"
+                  description: Optional systemd machine-id (32 lowercase hex characters, used for /etc/machine-id)
       additionalPrinterColumns:
         - name: MAC
           type: string


### PR DESCRIPTION
## Summary
Add optional `machineId` field to Machine CRD for systemd machine-id support.

## Changes
- `crds/machine.yaml`: Add `machineId` field with pattern `^[0-9a-fA-F]{32}$`
- `crds/CLAUDE.md`: Document machineId field

## Usage
```yaml
apiVersion: isoboot.io/v1alpha1
kind: Machine
metadata:
  name: vm-01.lan
spec:
  mac: "aa-bb-cc-dd-ee-ff"
  machineId: "0123456789abcdef0123456789abcdef"  # optional
```

## Related
- isoboot/isoboot#32 - Go code changes

## Test plan
- [ ] Apply CRD to cluster
- [ ] Create Machine with valid machineId
- [ ] Verify invalid machineId is rejected by OpenAPI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)