### PR TITLE
feat: add machineId field to Provision CRD

### DIFF
--- a/crds/provision.yaml
+++ b/crds/provision.yaml
@@ -49,6 +49,10 @@ spec:
                   items:
                     type: string
                     minLength: 1
+                machineId:
+                  type: string
+                  pattern: "^[0-9a-f]{32}$"
+                  description: Optional systemd machine-id (32 lowercase hex characters, used for /etc/machine-id)
             status:
               type: object
               properties:


### PR DESCRIPTION
## Summary
Add optional `machineId` field to Provision spec, enabling per-installation machine IDs instead of per-hardware.

## Changes
- Add `machineId` field to Provision CRD with pattern `^[0-9a-f]{32}$`

## Backwards Compatible
This is additive - existing `Machine.machineId` field is still supported. The Go code (companion PR) will prefer `Provision.machineId` if set, falling back to `Machine.machineId`.

## Related
- Companion PR: https://github.com/isoboot/isoboot/pull/35

## Test plan
- [ ] Deploy updated CRD
- [ ] Create Provision with machineId, verify it's accepted
- [ ] Create Provision without machineId, verify it works with Machine.machineId

🤖 Generated with [Claude Code](https://claude.com/claude-code)