### PR TITLE
feat: use ProvisionName in boot template answer URLs

### DIFF
--- a/files/boottarget-debian-v1.tpl
+++ b/files/boottarget-debian-v1.tpl
@@ -1,5 +1,5 @@
 #!ipxe
 kernel http://{{ .Host }}:{{ .Port }}/iso/content/{{ .BootTarget }}/mini.iso/linux
 initrd http://{{ .Host }}:{{ .Port }}/iso/content/{{ .BootTarget }}/mini.iso/initrd.gz
-imgargs linux initrd=initrd.gz auto=true priority=critical ipv6.disable=1 netcfg/choose_interface=auto hostname={{ .Hostname }} domain={{ .Domain }} mirror/http/proxy=http://{{ .Host }}:3128 preseed/url=http://{{ .Host }}:{{ .Port }}/answer/{{ .MachineName }}/preseed.cfg --- quiet
+imgargs linux initrd=initrd.gz auto=true priority=critical ipv6.disable=1 netcfg/choose_interface=auto hostname={{ .Hostname }} domain={{ .Domain }} mirror/http/proxy=http://{{ .Host }}:3128 preseed/url=http://{{ .Host }}:{{ .Port }}/answer/{{ .ProvisionName }}/preseed.cfg --- quiet
 boot


### PR DESCRIPTION
## Summary
Update boot template to use `{{ .ProvisionName }}` for answer file URLs instead of `{{ .MachineName }}`, enabling O(1) lookup by provision name.

## Changes
- Update `boottarget-debian-v1.tpl` to use `{{ .ProvisionName }}` in preseed URL

## Breaking Change
Boot templates now use `ProvisionName` instead of `MachineName` for answer file URLs.

## Related
- Companion PR: isoboot/isoboot#TBD

## Test plan
- [ ] Deploy with updated Go code
- [ ] Boot machine, verify preseed URL uses provision name
- [ ] Verify answer file is retrieved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)