### PR TITLE
feat: remove machineId from Machine CRD

### DIFF
--- a/crds/machine.yaml
+++ b/crds/machine.yaml
@@ -31,18 +31,10 @@ spec:
                   type: string
                   pattern: "^([0-9A-Fa-f]{2}-){5}([0-9A-Fa-f]{2})$"
                   description: MAC address for this machine (dash-separated, e.g., aa-bb-cc-dd-ee-ff)
-                machineId:
-                  type: string
-                  pattern: "^[0-9a-f]{32}$"
-                  description: Optional systemd machine-id (32 lowercase hex characters, used for /etc/machine-id)
       additionalPrinterColumns:
         - name: MAC
           type: string
           jsonPath: .spec.mac
-        - name: Machine ID
-          type: string
-          jsonPath: .spec.machineId
-          priority: 1
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
## Summary
Remove `machineId` field from Machine CRD as it belongs on Provision (per-installation, not per-hardware).

## Changes
- Remove `machineId` field from Machine CRD
- Remove Machine ID printer column

## Breaking Change
`Machine.machineId` has been removed. Users should migrate to using `Provision.machineId` instead.

## Migration
Before (Machine):
```yaml
spec:
  mac: "aa-bb-cc-dd-ee-ff"
  machineId: "0123456789abcdef0123456789abcdef"
```

After (Provision):
```yaml
spec:
  machineRef: vm-01.lan
  machineId: "0123456789abcdef0123456789abcdef"
  ...
```

## Related
- Prerequisite: isoboot/isoboot-chart#49 (adds machineId to Provision)
- Companion PR: isoboot/isoboot#TBD

## Test plan
- [ ] Deploy updated CRD
- [ ] Verify existing Machines without machineId still work
- [ ] Verify Provision.machineId works for template rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)