### PR TITLE
fix: remove http-host/http-port from controller deployment

### DIFF
--- a/templates/deployment-controller.yaml
+++ b/templates/deployment-controller.yaml
@@ -34,31 +34,16 @@ spec:
               echo "Installing isoboot-controller..."
               GOPROXY=direct go install github.com/isoboot/isoboot/cmd/isoboot-controller@{{ .Values.controller.commit }}
 
-              HTTP_PORT="{{ .Values.http.port }}"
-
-              if [ -z "${HOST_IP:-}" ]; then
-                echo "Error: HOST_IP environment variable is not set or empty." >&2
-                exit 1
-              fi
-
-              echo "Using host IP: ${HOST_IP}"
-
               echo "Starting isoboot-controller on :8081..."
               exec isoboot-controller \
                 --port="8081" \
                 --namespace="{{ .Release.Namespace }}" \
-                --iso-path="/opt/isoboot/iso" \
-                --http-host="${HOST_IP}" \
-                --http-port="${HTTP_PORT}"
+                --iso-path="/opt/isoboot/iso"
           env:
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
             - name: GOCACHE
               value: /go/cache
           ports:


### PR DESCRIPTION
## Summary

Remove `HOST_IP` environment variable and `--http-host`/`--http-port` flags from controller deployment.

## Why

After the gRPC primitive refactor (isoboot/isoboot#61), the controller no longer needs the HTTP server's host/port:
- Template rendering moved to HTTP handlers
- HTTP pod derives its own IP from the interface
- No more IP mismatch on multihomed nodes

## Changes

- Removed `HOST_IP` env var (was using `status.hostIP`)
- Removed `--http-host` and `--http-port` flags
- Removed HOST_IP check script

## Dependencies

Requires isoboot/isoboot#61 to be merged first (controller code changes).

🤖 Generated with [Claude Code](https://claude.ai/code)