### PR TITLE
fix: add not_available to fileSizeMatch enum in DiskImage CRD

### DIFF
--- a/crds/diskimage.yaml
+++ b/crds/diskimage.yaml
@@ -51,7 +51,7 @@ spec:
                   properties:
                     fileSizeMatch:
                       type: string
-                      enum: [pending, processing, verified, failed]
+                      enum: [pending, processing, verified, failed, not_available]
                     digestSha512:
                       type: string
                       enum: [pending, processing, verified, failed, not_found]
@@ -67,7 +67,7 @@ spec:
                   properties:
                     fileSizeMatch:
                       type: string
-                      enum: [pending, processing, verified, failed]
+                      enum: [pending, processing, verified, failed, not_available]
                     digestSha512:
                       type: string
                       enum: [pending, processing, verified, failed, not_found]


### PR DESCRIPTION
## Summary

- Add `not_available` to `fileSizeMatch` enum for both `iso` and `firmware` status fields
- Required when servers don't send Content-Length header (e.g., chunked encoding)

## Context

The controller writes `fileSizeMatch: "not_available"` when Content-Length is missing from HTTP response. Without this enum value, Kubernetes API server rejects the status update.

## Related

- isoboot/isoboot#62 - Controller change (GET+abort instead of HEAD)

## Test plan

- [ ] Apply updated CRD: `kubectl apply -f crds/diskimage.yaml`
- [ ] Verify controller can set `fileSizeMatch: not_available` without API rejection

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)