### PR TITLE
chore: update isoboot to cb69f10

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@
 # HTTP server for boot files (no k8s access, talks to controller via gRPC)
 http:
   port: 8080
-  commit: "a0614dd"  # Git commit to install
+  commit: "cb69f10"  # Git commit to install
   resources:
     limits:
       memory: "512Mi"
@@ -16,7 +16,7 @@ http:
 
 # Controller (manages provisions, talks to k8s API)
 controller:
-  commit: "a0614dd"  # Git commit to install
+  commit: "cb69f10"  # Git commit to install
   resources:
     limits:
       memory: "512Mi"


### PR DESCRIPTION
## Summary

Update controller and HTTP server to latest isoboot commit.

## Changes included

- fix: use GET+abort instead of HEAD for file size check (#62)
- fix: remove http-host/http-port from controller (#61)

## Test plan

- [ ] `helm upgrade` and verify pods restart with new code
- [ ] Test DiskImage download from server without HEAD support

🤖 Generated with [Claude Code](https://claude.com/claude-code)