### PR TITLE
fix: pass --proxy-port to isoboot-http

### DIFF
--- a/templates/deployment-http.yaml
+++ b/templates/deployment-http.yaml
@@ -47,6 +47,7 @@ spec:
               exec isoboot-http \
                 --host="${HOST_IP}" \
                 --port="${HTTP_PORT}" \
+                --proxy-port="{{ .Values.proxy.port }}" \
                 --controller="${CONTROLLER_ADDR}" \
                 --templates-configmap="{{ include "isoboot.fullname" . }}-templates" \
                 --iso-path="/opt/isoboot/iso"


### PR DESCRIPTION
## Summary

Pass `--proxy-port="{{ .Values.proxy.port }}"` to isoboot-http deployment.

## Problem

Without this flag, isoboot-http uses the default proxy port (3128) even if `values.proxy.port` is changed. The boot template now uses `{{ .ProxyPort }}`, but it would always render as 3128.

## Test plan

- [ ] Change `proxy.port` in values.yaml
- [ ] Boot a VM and verify installer uses the configured port

🤖 Generated with [Claude Code](https://claude.com/claude-code)