### PR TITLE
chore: update isoboot to 4f47b04

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@
 # HTTP server for boot files (no k8s access, talks to controller via gRPC)
 http:
   port: 8080
-  commit: "432ee8e"  # Git commit to install
+  commit: "4f47b04"  # Git commit to install
   resources:
     limits:
       memory: "512Mi"
@@ -16,7 +16,7 @@ http:
 
 # Controller (manages provisions, talks to k8s API)
 controller:
-  commit: "432ee8e"  # Git commit to install
+  commit: "4f47b04"  # Git commit to install
   resources:
     limits:
       memory: "512Mi"


### PR DESCRIPTION
## ⚠️ Breaking Change

`/boot/done` now uses `?mac={{ .MAC }}` instead of `?id={{ .Hostname }}`.

## Summary

Update controller and HTTP server to latest isoboot commit.

## Changes included

- feat!: change /boot/done to use mac parameter (#66)
- `GetMachine` gRPC method to retrieve MAC by name
- `{{ .MAC }}` variable in ResponseTemplate data

## Migration

Update preseed late_command from:
```
wget http://{{ .Host }}:{{ .Port }}/boot/done?id={{ .Hostname }}
```

To:
```
wget http://{{ .Host }}:{{ .Port }}/boot/done?mac={{ .MAC }}
```

## Test plan

- [ ] `helm upgrade` and verify pods restart
- [ ] Test boot completion with new `?mac=` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)