### PR TITLE
Clean up hardcoded values, naming, probes, and CRD validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ helm install isoboot ./isoboot-chart --set interface=br1
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `image.repository` | `alpine` | Container image repository |
-| `image.tag` | `latest` | Container image tag |
-| `image.pullPolicy` | `Always` | Image pull policy |
+| `image.tag` | `3.23` | Container image tag |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `resources.limits.memory` | `128Mi` | Memory limit |
 | `resources.limits.cpu` | `500m` | CPU limit |
 | `resources.requests.memory` | `64Mi` | Memory request |
@@ -65,9 +65,13 @@ When a PXE client boots:
 
 | Port | Protocol | Purpose |
 |------|----------|---------|
-| 67 | UDP | DHCP (proxy mode) |
-| 69 | UDP | TFTP |
-| 4011 | UDP | PXE proxy DHCP |
+| 67 | UDP | DHCP (proxy mode, dnsmasq) |
+| 69 | UDP | TFTP (dnsmasq) |
+| 80 | TCP | HTTP server (isoboot-http, internal) |
+| 3128 | TCP | Caching proxy (squid) |
+| 4011 | UDP | PXE proxy DHCP (dnsmasq) |
+| 8080 | TCP | Reverse proxy (nginx, external) |
+| 18080 | TCP | gRPC (isoboot-controller) |
 
 ## Uninstall
 

--- a/crds/provision.yaml
+++ b/crds/provision.yaml
@@ -29,9 +29,11 @@ spec:
               properties:
                 machineRef:
                   type: string
+                  minLength: 1
                   description: Reference to a Machine resource name
                 bootTargetRef:
                   type: string
+                  minLength: 1
                   description: Reference to a BootTarget resource name
                 responseTemplateRef:
                   type: string

--- a/templates/deployment-controller.yaml
+++ b/templates/deployment-controller.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: {{ include "isoboot.fullname" . }}-controller
       containers:
         - name: controller
-          image: "golang:1.25-alpine"
+          image: "{{ .Values.go.image }}"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -34,9 +34,9 @@ spec:
               echo "Installing isoboot-controller..."
               GOPROXY=direct go install github.com/isoboot/isoboot/cmd/isoboot-controller@{{ .Values.commit }}
 
-              echo "Starting isoboot-controller on :8081..."
+              echo "Starting isoboot-controller on :{{ .Values.controller.port }}..."
               exec isoboot-controller \
-                --port="8081" \
+                --port="{{ .Values.controller.port }}" \
                 --namespace="{{ .Release.Namespace }}" \
                 --files-path="/opt/isoboot/files"
           env:
@@ -48,7 +48,7 @@ spec:
               value: /go/cache
           ports:
             - name: grpc
-              containerPort: 8081
+              containerPort: {{ .Values.controller.port }}
               protocol: TCP
           volumeMounts:
             - name: go-cache
@@ -59,14 +59,19 @@ spec:
             {{- toYaml .Values.controller.resources | nindent 12 }}
           livenessProbe:
             tcpSocket:
-              port: 8081
+              port: {{ .Values.controller.port }}
             initialDelaySeconds: 30
             periodSeconds: 30
           readinessProbe:
             tcpSocket:
-              port: 8081
+              port: {{ .Values.controller.port }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          startupProbe:
+            tcpSocket:
+              port: {{ .Values.controller.port }}
+            failureThreshold: 30
+            periodSeconds: 10
       volumes:
         - name: go-cache
           hostPath:
@@ -89,6 +94,6 @@ spec:
     app.kubernetes.io/component: controller
   ports:
     - name: grpc
-      port: 8081
-      targetPort: 8081
+      port: {{ .Values.controller.port }}
+      targetPort: {{ .Values.controller.port }}
       protocol: TCP

--- a/templates/deployment-http.yaml
+++ b/templates/deployment-http.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: http
-          image: "golang:1.25-alpine"
+          image: "{{ .Values.go.image }}"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -29,7 +29,7 @@ spec:
             - |
               set -e
               INTERFACE="{{ required "interface is required" .Values.interface }}"
-              CONTROLLER_ADDR="{{ include "isoboot.fullname" . }}-controller.{{ .Release.Namespace }}.svc.cluster.local:8081"
+              CONTROLLER_ADDR="{{ include "isoboot.fullname" . }}-controller.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.controller.port }}"
 
               echo "Installing dependencies..."
               apk add --no-cache git iproute2
@@ -77,6 +77,12 @@ spec:
               port: {{ .Values.http.listenPort }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.http.listenPort }}
+            failureThreshold: 30
+            periodSeconds: 10
       volumes:
         - name: go-cache
           hostPath:

--- a/templates/deployment-squid.yaml
+++ b/templates/deployment-squid.yaml
@@ -101,7 +101,7 @@ spec:
             tcpSocket:
               port: {{ .Values.proxy.port }}
             initialDelaySeconds: 10
-            periodSeconds: 10
+            periodSeconds: 5
       volumes:
         - name: squid-cache
           hostPath:

--- a/templates/pod-dnsmasq.yaml
+++ b/templates/pod-dnsmasq.yaml
@@ -8,7 +8,7 @@ spec:
   restartPolicy: Always
   hostNetwork: true
   containers:
-    - name: pxe-server
+    - name: dnsmasq
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       command:
@@ -20,7 +20,7 @@ spec:
           HTTP_PORT="{{ .Values.http.port }}"
 
           echo "Installing dnsmasq, iproute2, and ipcalc..."
-          apk add --no-cache dnsmasq iproute2 ipcalc
+          apk add --no-cache dnsmasq iproute2 ipcalc gettext
 
           echo "Detecting network info from interface ${INTERFACE}..."
           IP_CIDR=$(ip -4 addr show "${INTERFACE}" | awk '/inet / {print $2}' | head -1)
@@ -77,7 +77,9 @@ spec:
           log-dhcp
           DNSMASQ_EOF
           sed -i 's/^          //' /tmp/dnsmasq.conf
-          sed -i "s/\${INTERFACE}/${INTERFACE}/g; s/\${SUBNET}/${SUBNET}/g; s/\${HOST_IP}/${HOST_IP}/g; s/\${HTTP_PORT}/${HTTP_PORT}/g" /tmp/dnsmasq.conf
+          export INTERFACE SUBNET HOST_IP HTTP_PORT
+          envsubst < /tmp/dnsmasq.conf > /tmp/dnsmasq.final.conf
+          mv /tmp/dnsmasq.final.conf /tmp/dnsmasq.conf
 
           echo "dnsmasq config:"
           cat /tmp/dnsmasq.conf

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,10 @@
 # Go commit to install for both http and controller
 commit: "aa6aba2"
 
+# Go build image for http and controller
+go:
+  image: "golang:1.25-alpine"
+
 # HTTP server for boot files (no k8s access, talks to controller via gRPC)
 http:
   port: 8080        # External port (nginx listens here, used in templates)
@@ -19,6 +23,7 @@ http:
 
 # Controller (manages provisions, talks to k8s API)
 controller:
+  port: 18080  # gRPC port
   resources:
     limits:
       memory: "512Mi"


### PR DESCRIPTION
## Summary
- Extract Go image to `values.yaml` (`go.image`) so it can be overridden without editing templates
- Extract controller gRPC port to `values.yaml` (`controller.port: 18080`), replacing 6 hardcoded `8081` references
- Add startup probes to http and controller deployments (30×10s = 300s budget for Go compilation)
- Fix squid readiness probe period (10s → 5s) to match other deployments
- Rename dnsmasq container from `pxe-server` to `dnsmasq` for clarity
- Replace `sed` variable substitution with `envsubst` in dnsmasq config generation
- Add `minLength: 1` validation to `machineRef` and `bootTargetRef` in Provision CRD
- Update README ports table with all services and fix stale parameter defaults (`latest` → `3.23`, `Always` → `IfNotPresent`)

## Test plan
- [ ] `helm template . --set interface=br1` renders all templates correctly
- [ ] `helm template . --set interface=br1 --set go.image=golang:1.24-alpine` overrides Go image in both http and controller
- [ ] Startup probes, container names, and CRD minLength appear correctly in rendered output
- [ ] Deploy and verify dnsmasq config generates correctly with envsubst

🤖 Generated with [Claude Code](https://claude.com/claude-code)