### PR TITLE
Move PXE install test to nightly schedule

### DIFF
--- a/.github/workflows/nightly-pxe-test.yml
+++ b/.github/workflows/nightly-pxe-test.yml
@@ -1,9 +1,9 @@
-name: PXE Install Test
+name: Nightly PXE Install Test
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
 
 jobs:
   pxe-install:
@@ -91,24 +91,31 @@ jobs:
           path: /tmp/isoboot-cache
           key: isoboot-cache-v6-${{ env.COMMIT }}
 
-      - name: Debug on failure
+      - name: Collect debug logs
         if: failure()
         run: |
-          echo "=== QEMU serial log ==="
-          cat /tmp/pxe-install-test/serial.log 2>/dev/null || echo "(no serial log)"
-          echo ""
-          echo "=== dnsmasq log ==="
-          tail -100 /tmp/pxe-install-test/dnsmasq.log 2>/dev/null || echo "(no dnsmasq log)"
-          echo ""
-          echo "=== CRD Status ==="
-          kubectl get bootsource,provision,machine,boottarget,responsetemplate \
-            -n isoboot -o wide 2>/dev/null || true
-          echo ""
-          echo "=== Pod Status ==="
-          kubectl get pods -n isoboot -o wide 2>/dev/null || true
-          echo ""
-          echo "=== Pod Logs ==="
-          for pod in $(kubectl get pods -n isoboot -o name 2>/dev/null); do
-            echo "--- $pod ---"
-            kubectl logs "$pod" -n isoboot --all-containers=true --tail=100 || true
-          done
+          mkdir -p /tmp/pxe-test-artifacts
+          cp /tmp/pxe-install-test/serial.log /tmp/pxe-test-artifacts/ 2>/dev/null || true
+          cp /tmp/pxe-install-test/dnsmasq.log /tmp/pxe-test-artifacts/ 2>/dev/null || true
+          {
+            echo "=== CRD Status ==="
+            kubectl get bootsource,provision,machine,boottarget,responsetemplate \
+              -n isoboot -o wide 2>/dev/null || true
+            echo ""
+            echo "=== Pod Status ==="
+            kubectl get pods -n isoboot -o wide 2>/dev/null || true
+            echo ""
+            echo "=== Pod Logs ==="
+            for pod in $(kubectl get pods -n isoboot -o name 2>/dev/null); do
+              echo "--- $pod ---"
+              kubectl logs "$pod" -n isoboot --all-containers=true --tail=100 || true
+            done
+          } > /tmp/pxe-test-artifacts/kubernetes.log 2>&1
+
+      - name: Upload debug artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pxe-test-logs
+          path: /tmp/pxe-test-artifacts/
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Nightly PXE Test](https://github.com/isoboot/isoboot-chart/actions/workflows/nightly-pxe-test.yml/badge.svg)](https://github.com/isoboot/isoboot-chart/actions/workflows/nightly-pxe-test.yml)
+
 # isoboot-chart
 
 PXE boot proxy DHCP server using dnsmasq and iPXE.


### PR DESCRIPTION
Closes #107

## Summary
- Change PXE install test from running on every push/PR to a nightly schedule (daily at 6am UTC) with manual `workflow_dispatch`
- Rename workflow file `pxe-install.yaml` → `nightly-pxe-test.yml`
- Upload serial, dnsmasq, and Kubernetes logs as artifacts on failure (14-day retention)
- Add nightly PXE test status badge to top of README.md

## Test plan
- [ ] `workflow_dispatch` trigger works for on-demand runs
- [ ] Artifacts are uploaded on test failure
- [ ] Badge renders correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)