### PR TITLE
Fix preseed inconsistencies in examples 03 and 04

### DIFF
--- a/examples/03-debian-13-with-ssh-host-keys.md
+++ b/examples/03-debian-13-with-ssh-host-keys.md
@@ -97,14 +97,16 @@ spec:
       d-i debian-installer/country string {{ .country }}
       d-i keyboard-configuration/xkb-keymap select {{ .keyboard }}
       d-i passwd/root-login boolean {{ .loginAsRoot }}
-      d-i passwd/user-fullname {{ .fullName }}
+      d-i passwd/user-fullname string {{ .fullName }}
       d-i passwd/username string {{ .username }}
       d-i passwd/user-password-crypted password {{ .password }}
       d-i time/zone string {{ .timezone }}
       d-i partman-auto/method string regular
+      d-i partman-auto/choose_recipe select atomic
       d-i partman/choose_partition select finish
       d-i partman/confirm_nooverwrite boolean true
       d-i partman/confirm boolean true
+      d-i grub-installer/only_debian boolean true
       d-i finish-install/reboot_in_progress note
       d-i preseed/late_command string \
         echo "Processing SSH public key..." >> /target/root/late_command.log && \

--- a/examples/04-debian-13-with-machine-id.md
+++ b/examples/04-debian-13-with-machine-id.md
@@ -104,14 +104,16 @@ spec:
       d-i debian-installer/country string {{ .country }}
       d-i keyboard-configuration/xkb-keymap select {{ .keyboard }}
       d-i passwd/root-login boolean {{ .loginAsRoot }}
-      d-i passwd/user-fullname {{ .fullName }}
+      d-i passwd/user-fullname string {{ .fullName }}
       d-i passwd/username string {{ .username }}
       d-i passwd/user-password-crypted password {{ .password }}
       d-i time/zone string {{ .timezone }}
       d-i partman-auto/method string regular
+      d-i partman-auto/choose_recipe select atomic
       d-i partman/choose_partition select finish
       d-i partman/confirm_nooverwrite boolean true
       d-i partman/confirm boolean true
+      d-i grub-installer/only_debian boolean true
       d-i finish-install/reboot_in_progress note
       d-i preseed/late_command string \
         echo "Processing SSH public key..." >> /target/root/late_command.log && \


### PR DESCRIPTION
## Summary
- Add missing `string` keyword to `d-i passwd/user-fullname` in examples 03 and 04
- Add missing `d-i partman-auto/choose_recipe select atomic` in examples 03 and 04
- Add missing `d-i grub-installer/only_debian boolean true` in examples 03 and 04

These directives are present in examples 01/02 and all integration tests. Without `grub-installer/only_debian`, the installer may prompt interactively. Without `choose_recipe`, partition layout may differ.

The endpoint fix (`/boot/done` -> `/dynamic/boot/done`) was already addressed in PR #126.

## Test plan
- [ ] Examples 03 and 04 preseed directives now match examples 01/02 and integration tests

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)