### PR TITLE
Use b64enc for sshPublicKey and MachineId in late_command

### DIFF
--- a/examples/02-basic-debian-13-with-public-ssh-key.md
+++ b/examples/02-basic-debian-13-with-public-ssh-key.md
@@ -41,7 +41,7 @@ spec:
       d-i preseed/late_command string \
         in-target mkdir -p /home/{{ .username }}/.ssh && \
         in-target chmod 700 /home/{{ .username }}/.ssh && \
-        echo '{{ .sshPublicKey }}' > /target/home/{{ .username }}/.ssh/authorized_keys && \
+        echo '{{ .sshPublicKey | b64enc }}' | base64 -d > /target/home/{{ .username }}/.ssh/authorized_keys && \
         in-target chmod 600 /home/{{ .username }}/.ssh/authorized_keys && \
         in-target chown -R {{ .username }}:{{ .username }} /home/{{ .username }}/.ssh && \
         wget -qO- http://{{ .Host }}:{{ .Port }}/dynamic/boot/done?mac={{ .MAC }}

--- a/examples/03-debian-13-with-ssh-host-keys.md
+++ b/examples/03-debian-13-with-ssh-host-keys.md
@@ -113,7 +113,7 @@ spec:
       {{- if and (hasKey . "sshPublicKey") .sshPublicKey (hasKey . "username") .username }}
         in-target mkdir -p /home/{{ .username }}/.ssh && \
         in-target chmod 700 /home/{{ .username }}/.ssh && \
-        echo '{{ .sshPublicKey }}' > /target/home/{{ .username }}/.ssh/authorized_keys && \
+        echo '{{ .sshPublicKey | b64enc }}' | base64 -d > /target/home/{{ .username }}/.ssh/authorized_keys && \
         in-target chmod 600 /home/{{ .username }}/.ssh/authorized_keys && \
         in-target chown -R {{ .username }}:{{ .username }} /home/{{ .username }}/.ssh && \
       {{- end }}

--- a/examples/04-debian-13-with-machine-id.md
+++ b/examples/04-debian-13-with-machine-id.md
@@ -126,7 +126,7 @@ spec:
       {{- end }}
       {{- if hasKey . "MachineId" }}
         echo "Processing Machine Id..." >> /target/root/late_command.log && \
-        echo '{{ .MachineId | b64enc }}' | base64 -d > /target/etc/machine-id && \
+        { echo '{{ .MachineId | b64enc }}' | base64 -d; echo; } > /target/etc/machine-id && \
         chmod 444 /target/etc/machine-id && \
       {{- end }}
       {{- if and (hasKey . "ssh_host_ed25519_key") (hasKey . "ssh_host_ed25519_key_pub") }}

--- a/examples/04-debian-13-with-machine-id.md
+++ b/examples/04-debian-13-with-machine-id.md
@@ -120,13 +120,13 @@ spec:
       {{- if and (hasKey . "sshPublicKey") .sshPublicKey (hasKey . "username") .username }}
         in-target mkdir -p /home/{{ .username }}/.ssh && \
         in-target chmod 700 /home/{{ .username }}/.ssh && \
-        echo '{{ .sshPublicKey }}' > /target/home/{{ .username }}/.ssh/authorized_keys && \
+        echo '{{ .sshPublicKey | b64enc }}' | base64 -d > /target/home/{{ .username }}/.ssh/authorized_keys && \
         in-target chmod 600 /home/{{ .username }}/.ssh/authorized_keys && \
         in-target chown -R {{ .username }}:{{ .username }} /home/{{ .username }}/.ssh && \
       {{- end }}
       {{- if hasKey . "MachineId" }}
         echo "Processing Machine Id..." >> /target/root/late_command.log && \
-        echo '{{ .MachineId }}' > /target/etc/machine-id && \
+        echo '{{ .MachineId | b64enc }}' | base64 -d > /target/etc/machine-id && \
         chmod 444 /target/etc/machine-id && \
       {{- end }}
       {{- if and (hasKey . "ssh_host_ed25519_key") (hasKey . "ssh_host_ed25519_key_pub") }}

--- a/examples/05-debian-13-secure.md
+++ b/examples/05-debian-13-secure.md
@@ -77,7 +77,7 @@ spec:
       {{- if and (hasKey . "sshPublicKey") .sshPublicKey (hasKey . "username") .username }}
         in-target mkdir -p /home/{{ .username }}/.ssh && \
         in-target chmod 700 /home/{{ .username }}/.ssh && \
-        echo '{{ .sshPublicKey }}' > /target/home/{{ .username }}/.ssh/authorized_keys && \
+        echo '{{ .sshPublicKey | b64enc }}' | base64 -d > /target/home/{{ .username }}/.ssh/authorized_keys && \
         in-target chmod 600 /home/{{ .username }}/.ssh/authorized_keys && \
         in-target chown -R {{ .username }}:{{ .username }} /home/{{ .username }}/.ssh && \
       {{- end }}
@@ -100,7 +100,7 @@ spec:
         chmod 644 /target/etc/ssh/ssh_host_rsa_key.pub && \
       {{- end }}
       {{- if hasKey . "MachineId" }}
-        echo '{{ .MachineId }}' > /target/etc/machine-id && \
+        echo '{{ .MachineId | b64enc }}' | base64 -d > /target/etc/machine-id && \
         chmod 444 /target/etc/machine-id && \
       {{- end }}
         in-target sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config && \

--- a/examples/05-debian-13-secure.md
+++ b/examples/05-debian-13-secure.md
@@ -100,7 +100,7 @@ spec:
         chmod 644 /target/etc/ssh/ssh_host_rsa_key.pub && \
       {{- end }}
       {{- if hasKey . "MachineId" }}
-        echo '{{ .MachineId | b64enc }}' | base64 -d > /target/etc/machine-id && \
+        { echo '{{ .MachineId | b64enc }}' | base64 -d; echo; } > /target/etc/machine-id && \
         chmod 444 /target/etc/machine-id && \
       {{- end }}
         in-target sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config && \

--- a/tests/integration/pxe-install/cases/02-debian-13-ssh-key/fixtures.yaml
+++ b/tests/integration/pxe-install/cases/02-debian-13-ssh-key/fixtures.yaml
@@ -34,7 +34,7 @@ spec:
       d-i preseed/late_command string \
         in-target mkdir -p /home/{{ .username }}/.ssh && \
         in-target chmod 700 /home/{{ .username }}/.ssh && \
-        echo '{{ .sshPublicKey }}' > /target/home/{{ .username }}/.ssh/authorized_keys && \
+        echo '{{ .sshPublicKey | b64enc }}' | base64 -d > /target/home/{{ .username }}/.ssh/authorized_keys && \
         in-target chmod 600 /home/{{ .username }}/.ssh/authorized_keys && \
         in-target chown -R {{ .username }}:{{ .username }} /home/{{ .username }}/.ssh && \
         wget -qO- http://{{ .Host }}:{{ .Port }}/dynamic/boot/done?mac={{ .MAC }}

--- a/tests/integration/pxe-install/cases/04-debian-13-machine-id/fixtures.yaml
+++ b/tests/integration/pxe-install/cases/04-debian-13-machine-id/fixtures.yaml
@@ -33,7 +33,7 @@ spec:
       d-i finish-install/reboot_in_progress note
       d-i preseed/late_command string \
       {{- if hasKey . "MachineId" }}
-        echo '{{ .MachineId }}' > /target/etc/machine-id && \
+        echo '{{ .MachineId | b64enc }}' | base64 -d > /target/etc/machine-id && \
         chmod 444 /target/etc/machine-id && \
       {{- end }}
         wget -qO- http://{{ .Host }}:{{ .Port }}/dynamic/boot/done?mac={{ .MAC }}

--- a/tests/integration/pxe-install/cases/04-debian-13-machine-id/fixtures.yaml
+++ b/tests/integration/pxe-install/cases/04-debian-13-machine-id/fixtures.yaml
@@ -33,7 +33,7 @@ spec:
       d-i finish-install/reboot_in_progress note
       d-i preseed/late_command string \
       {{- if hasKey . "MachineId" }}
-        echo '{{ .MachineId | b64enc }}' | base64 -d > /target/etc/machine-id && \
+        { echo '{{ .MachineId | b64enc }}' | base64 -d; echo; } > /target/etc/machine-id && \
         chmod 444 /target/etc/machine-id && \
       {{- end }}
         wget -qO- http://{{ .Host }}:{{ .Port }}/dynamic/boot/done?mac={{ .MAC }}

--- a/tests/integration/pxe-install/cases/05-debian-13-secure/fixtures.yaml
+++ b/tests/integration/pxe-install/cases/05-debian-13-secure/fixtures.yaml
@@ -35,7 +35,7 @@ spec:
       {{- if and (hasKey . "sshPublicKey") .sshPublicKey (hasKey . "username") .username }}
         in-target mkdir -p /home/{{ .username }}/.ssh && \
         in-target chmod 700 /home/{{ .username }}/.ssh && \
-        echo '{{ .sshPublicKey }}' > /target/home/{{ .username }}/.ssh/authorized_keys && \
+        echo '{{ .sshPublicKey | b64enc }}' | base64 -d > /target/home/{{ .username }}/.ssh/authorized_keys && \
         in-target chmod 600 /home/{{ .username }}/.ssh/authorized_keys && \
         in-target chown -R {{ .username }}:{{ .username }} /home/{{ .username }}/.ssh && \
       {{- end }}
@@ -58,7 +58,7 @@ spec:
         chmod 644 /target/etc/ssh/ssh_host_rsa_key.pub && \
       {{- end }}
       {{- if hasKey . "MachineId" }}
-        echo '{{ .MachineId }}' > /target/etc/machine-id && \
+        echo '{{ .MachineId | b64enc }}' | base64 -d > /target/etc/machine-id && \
         chmod 444 /target/etc/machine-id && \
       {{- end }}
         in-target sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config && \

--- a/tests/integration/pxe-install/cases/05-debian-13-secure/fixtures.yaml
+++ b/tests/integration/pxe-install/cases/05-debian-13-secure/fixtures.yaml
@@ -58,7 +58,7 @@ spec:
         chmod 644 /target/etc/ssh/ssh_host_rsa_key.pub && \
       {{- end }}
       {{- if hasKey . "MachineId" }}
-        echo '{{ .MachineId | b64enc }}' | base64 -d > /target/etc/machine-id && \
+        { echo '{{ .MachineId | b64enc }}' | base64 -d; echo; } > /target/etc/machine-id && \
         chmod 444 /target/etc/machine-id && \
       {{- end }}
         in-target sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config && \


### PR DESCRIPTION
## Summary

- Applies `b64enc` encoding to `sshPublicKey` and `MachineId` template variables in preseed `late_command` blocks
- Prevents shell injection if values contain single quotes or shell metacharacters
- Matches the safe pattern already used for SSH host keys (`ssh_host_*_key`)

## Changes

All `echo '{{ .var }}'` patterns changed to `echo '{{ .var | b64enc }}' | base64 -d`:

| Variable | Files |
|----------|-------|
| `sshPublicKey` | fixtures 02, 05; examples 02, 03, 04, 05 |
| `MachineId` | fixtures 04, 05; examples 04, 05 |

For `MachineId`, the decode is wrapped in `{ ...; echo; }` to preserve the trailing newline that `/etc/machine-id` requires (32 hex chars + `\n` = 33 bytes).

## Why

Template variables embedded directly in single-quoted shell strings can break out of the quoting context. While the risk is low (values come from cluster-admin-controlled ConfigMaps/Secrets), the safe pattern is already established for host keys and should be applied consistently.

Fixes #131

## Test plan

- [ ] Run PXE integration tests — all 5 cases must pass with the b64enc change
- [ ] Verify SSH public key is correctly written to authorized_keys
- [ ] Verify machine-id is correctly written and matches expected value (33 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)